### PR TITLE
changing the "this" references to self in logging lib

### DIFF
--- a/lib/kido.logging.js
+++ b/lib/kido.logging.js
@@ -1,4 +1,3 @@
-
 /**
  * access to the logging backend service.
  *
@@ -15,23 +14,23 @@ var KidoLogging = function ( kidoApp ) {
     this.app = kidoApp;
 
     this.writeVerbose = function (data) {
-        return this.write(data, 0);
+        return self.write(data, 0);
     };
 
     this.writeInfo = function (data) {
-        return this.write(data, 1);
+        return self.write(data, 1);
     };
 
     this.writeWarning = function (data) {
-        return this.write(data, 2);
+        return self.write(data, 2);
     };
 
     this.writeError = function (data) {
-        return this.write(data, 3);
+        return self.write(data, 3);
     };
 
     this.writeCritical = function (data) {
-        return this.write(data, 4);
+        return self.write(data, 4);
     };
 
     this.write = function (data, level) {


### PR DESCRIPTION
The following code was failing when invoking the logging API with an error `Uncaught TypeError: Object [object global] has no method 'write'`

``` js
var logging = kido.logging();

// just some helper methods to provide a 'nicer' api over the kido logging api
var log = {
    error: function (msg, data) {
        _log(logging.writeError, msg, data);
    },
    info: function (msg, data) {
        _log(logging.writeInfo, msg, data);
    }
}

var _log = function(handler, msg, data) {
    var logMsg = {
        msg: msg
    };
    if (data) logMsg['data'] = data;
    handler(logMsg).done(function (e) {
        console.log(e);
    });
};

```

We traced down the issue to the use of `this` inside the logging apis. These have been replaced with `self`. Please review and accept the patch. 
